### PR TITLE
Fix document duplicate check

### DIFF
--- a/classes/service/document_service.php
+++ b/classes/service/document_service.php
@@ -127,6 +127,30 @@ class document_service {
     }
 
     /**
+     * Retrieve duplicate submissions with user information.
+     *
+     * @return array List of duplicate documents with user names.
+     */
+    public function get_duplicates() {
+        global $DB;
+        $sql = "SELECT d1.id, d1.filename, u.firstname, u.lastname
+                FROM {blockchain_documents} d1
+                JOIN {blockchain_documents} d2 ON d1.file_hash = d2.file_hash AND d1.id < d2.id
+                JOIN {user} u ON d1.userid = u.id
+                WHERE d1.moduleid = ? AND d2.moduleid = ?";
+        $records = $DB->get_records_sql($sql, [$this->moduleid, $this->moduleid]);
+        $duplicates = [];
+        foreach ($records as $r) {
+            $duplicates[] = [
+                'id' => $r->id,
+                'filename' => $r->filename,
+                'user' => $r->firstname . ' ' . $r->lastname,
+            ];
+        }
+        return $duplicates;
+    }
+
+    /**
      * Get a specific document.
      *
      * @param int $documentid The document ID.

--- a/security.php
+++ b/security.php
@@ -36,7 +36,7 @@ require_login($course, false, $cm);
 require_capability('mod/blockchain:grade', $context);
 
 $service = new mod_blockchain_document_service($moduleid);
-$duplicates = $service->check_duplicates();
+$duplicates = $service->get_duplicates();
 
 $PAGE->set_url('/mod/blockchain/security.php', ['id' => $moduleid]);
 $PAGE->set_title(get_string('securitycheck', 'mod_blockchain'));


### PR DESCRIPTION
## Summary
- implement `get_duplicates` in `document_service`
- use new method in `security.php`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b023854883209d362f9f2b5dc9da